### PR TITLE
adding an overlay for the Cocoon core.properties file for uploads

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/WEB-INF/cocoon/properties/core.properties
+++ b/dspace/modules/xmlui/src/main/webapp/WEB-INF/cocoon/properties/core.properties
@@ -1,0 +1,111 @@
+# Delay between reload checks for the configuration in ms.
+# The check is only performed if reloading is turned on!
+org.apache.cocoon.reload-delay=1000
+
+# Allow reinstatiating (reloading) of the Cocoon instance. If this is
+# set to "true", a new Cocoon instance can be created using
+# the request parameter "cocoon-reload". It also enables that Cocoon is
+# reloaded when cocoon.xconf changes. Default is false for security reasons.
+# You can enable this for faster testing.
+org.apache.cocoon.reloading=false
+
+# Turn on reloading for specific parts:
+org.apache.cocoon.reloading.sitemap=true
+org.apache.cocoon.reload-delay.sitemap=5000
+org.apache.cocoon.reloading.config=true
+org.apache.cocoon.reloading.flow=false
+
+# Causes all files in multipart requests to be processed.
+# Default is true but the maximum allowed size is kept small for security reasons.
+# Unsupported values will be interpreted as false.
+org.apache.cocoon.uploads.enable=true
+
+# This parameter allows to specify where Cocoon should put uploaded files.
+# The path specified can be either absolute or relative to the context
+# path of the servlet. On the Windows platform, absolute directory must start
+# with volume: C:\Path\To\Upload\Directory
+#
+# The default directory is "upload-dir" in the work-directory
+org.apache.cocoon.uploads.directory=/var2/dspace-uploads
+
+# Causes all files in multipart requests to be saved to upload-dir.
+# Default is true for security reasons.
+# Unsupported values will be interpreted as false.
+org.apache.cocoon.uploads.autosave=true
+
+# Specify handling of name conflicts when saving uploaded files to disk.
+# Acceptable values are deny, allow, rename (default). Files are renamed
+# x_filename where x is an integer value incremented to make the new
+# filename unique.
+org.apache.cocoon.uploads.overwrite=rename
+
+# Specify maximum allowed size of the upload. Defaults to 10 Mb.
+# DSpace Community: 2GB. The HTTP spec allows this to be increased to 4GB but 
+# Cocoon places a limit because the parameter is read into a signed integer.
+org.apache.cocoon.uploads.maxsize=2147483647
+
+# This parameter allows to specify where Cocoon should create its page
+# and other objects cache. The path specified can be either absolute or
+# relative to the context path of the servlet. On the Windows platform,
+# absolute directory must start with volume: C:\Path\To\Cache\Directory
+#
+# The default directory is "cache-dir" in the work-directory.
+#org.apache.cocoon.cache.directory=WEB-INF/work/cache-dir
+
+# This parameter allows to specify where Cocoon should put it's
+# working files. The path specified is either absolute or relative
+# to the context path of the Cocoon servlet. On the Windows platform,
+# absolute directory must start with volume: C:\Path\To\Work\Directory
+#
+# The default directory is "cocoon-files" directory in the servlet
+# context's temp directory (context property javax.servlet.context.tempdir).
+#org.apache.cocoon.work.directory=WEB-INF/work
+
+# This parameter is used to list classes that should be loaded at
+# initialization time of the servlet. For example, JDBC Drivers used need to
+# be named here. Additional entries may be inserted here during build
+# depending on your build properties.
+#
+# For parent ServiceManager sample:
+#org.apache.cocoon.classloader.load.classes.parentcm=org.apache.cocoon.samples.parentcm.Configurator
+#
+# For IBM WebSphere:
+#org.apache.cocoon.classloader.load.classes.websphere=com.ibm.servlet.classloader.Handler
+
+# If you set this parameter to 'true', Cocoon will add processing
+# time to the end of each response. Value 'hide' adds processing time as an
+# HTML comment. By default, processing time is not added (corresponds to
+# value 'false').
+# NOTE: If you use this feature, Cocoon might generate a wrong content
+# length header in the response. This is due to the internal processing
+# of Readers and the Caching. So, this might be the reason if you get
+# a warning about a wrong content length.
+#  See http://issues.apache.org/bugzilla/show_bug.cgi?id=17370.
+#org.apache.cocoon.showtime=true
+#org.apache.cocoon.hideshowtime=true
+
+# Whether or not the X-Cocoon-Version response header will be included.
+# This is true by default, but there may be some circumstances when it
+# is not desired (e.g. "information hiding" for added security, or if
+# using jsp:include with Cocoon-generated pages produces a "response is
+# already committed" error).
+org.apache.cocoon.showcocoonversion=true
+
+# If true or not set, this class will try to catch and handle all Cocoon
+# exceptions. If false, it will rethrow them to the servlet container.
+org.apache.cocoon.manageexceptions=true
+
+# Set form encoding. This will be the character set used to decode request
+# parameters. If not set the ISO-8859-1 encoding will be assumed.
+#DSpace Community: Setting this to UTF-8 based on DSpace 1.5.1 configuration
+org.apache.cocoon.formencoding=UTF-8
+
+# Set servlet container encoding. If not set ISO-8859-1 encoding will be assumed.
+#DSpace Community: Setting this to UTF-8 based on DSpace 1.5.1 configuration
+org.apache.cocoon.containerencoding=UTF-8
+
+# If you're using the Avalon bridge and the Log4J logger (which is the default
+# logger for the Avalon bridge), then you can define the loglevel with this
+# property.
+org.apache.cocoon.log4j.loglevel=error
+org.apache.cocoon.log4j.loglevel.spring=error


### PR DESCRIPTION
We need to use a more reasonable path for the uploads folder.
