### PR TITLE
Lso 1497 make filtering pdfs sturdier

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
@@ -97,7 +97,7 @@ public class PDFFilter extends MediaFilter
             
             try
             {
-                pdfDoc = PDDocument.load(source);
+                pdfDoc = PDDocument.loadNonSeq(source, null);
                 pts.writeText(pdfDoc, writer);
             }
             finally

--- a/pom.xml
+++ b/pom.xml
@@ -1059,7 +1059,7 @@
          <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>1.8.7</version>
+            <version>1.8.10</version>
          </dependency>
          <dependency>
             <groupId>org.apache.pdfbox</groupId>


### PR DESCRIPTION
Use loadNonSeq method of PDFbox (instead of the load method), bumped up the version of PDFbox to 1.8.10 (from 1.8.7), tested, much sturdier now.
