### PR TITLE
LSO 1555 validate all xml during build

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -269,6 +269,33 @@
                         </executions>
                     </plugin>
 
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>xml-maven-plugin</artifactId>
+                        <version>1.0.1</version>
+                        <executions>
+                          <execution>
+                            <id>validate-config-xml</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                              <goal>validate</goal>
+                            </goals>
+                          </execution>
+                        </executions>
+                        <configuration>
+                          <validationSets>
+                            <validationSet>
+                                <dir>${agnostic.build.dir}/testing/dspace/config/spring/api</dir>
+                                 <includes>
+                                     <include>**/*.xml</include>
+                                 </includes>
+                             </validationSet>
+                           </validationSets>
+                        </configuration>
+                    </plugin>
+
+
                     <!-- Run Unit/Integration Testing! This plugin just kicks off the tests (when enabled). -->
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -291,9 +291,60 @@
                                      <include>**/*.xml</include>
                                  </includes>
                              </validationSet>
-                           </validationSets>
+                            <validationSet>
+                                <dir>${agnostic.build.dir}/testing/dspace/config/spring/xmlui</dir>
+                                 <includes>
+                                     <include>**/*.xml</include>
+                                 </includes>
+                            </validationSet>
+                            <validationSet>
+                                <dir>${agnostic.build.dir}/testing/dspace/config/pages</dir>
+                                 <includes>
+                                     <include>**/*.xml</include>
+                                 </includes>
+                             </validationSet>
+                             </validationSets>
                         </configuration>
                     </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>xml-maven-plugin</artifactId>
+                        <version>1.0.1</version>
+                        <executions>
+                          <execution>
+                            <id>QQQvalidate-i18n-xml</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                              <goal>validate</goal>
+                            </goals>
+                          </execution>
+                        </executions>
+                        <configuration>
+                          <validationSets>
+                            <validationSet>
+                                <dir>${agnostic.build.dir}/testing/dspace/config/spring/api</dir>
+                                 <includes>
+                                     <include>**/*.xml</include>
+                                 </includes>
+                             </validationSet>
+                            <validationSet>
+                                <dir>${agnostic.build.dir}/testing/dspace/config/spring/xmlui</dir>
+                                 <includes>
+                                     <include>**/*.xml</include>
+                                 </includes>
+                            </validationSet>
+                            <validationSet>
+                                <dir>${agnostic.build.dir}/testing/dspace/config/pages</dir>
+                                 <includes>
+                                     <include>**/*.xml</include>
+                                 </includes>
+                             </validationSet>
+                             </validationSets>
+                        </configuration>
+                    </plugin>
+
+
 
 
                     <!-- Run Unit/Integration Testing! This plugin just kicks off the tests (when enabled). -->

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -284,7 +284,7 @@
                         </executions>
                         <configuration>
                           <validationSets>
-                            <!-- validate ALL XML and XSL files -->
+                            <!-- validate ALL XML and XSL config files in the testing folder -->
                              <validationSet>
                                  <dir>${agnostic.build.dir}/testing</dir>
                                  <includes>
@@ -292,7 +292,15 @@
                                      <include>**/*.xsl</include>
                                  </includes>
                              </validationSet>
-                              </validationSets>
+                             <!-- validate ALL XML and XSL files throughout the project -->
+                             <validationSet>
+                                <dir>${root.basedir}</dir>
+                                 <includes>
+                                     <include>**/*.xml</include>
+                                     <include>**/*.xsl</include>
+                                 </includes>
+                              </validationSet>
+                          </validationSets>
                         </configuration>
                     </plugin>
 

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -269,14 +269,13 @@
                         </executions>
                     </plugin>
 
-
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>xml-maven-plugin</artifactId>
                         <version>1.0.1</version>
                         <executions>
                           <execution>
-                            <id>validate-config-xml</id>
+                            <id>validate-ALL-xml-and-xsl</id>
                             <phase>process-test-resources</phase>
                             <goals>
                               <goal>validate</goal>
@@ -285,62 +284,15 @@
                         </executions>
                         <configuration>
                           <validationSets>
-                            <validationSet>
-                                <dir>${agnostic.build.dir}/testing/dspace/config/spring/api</dir>
+                            <!-- validate ALL XML and XSL files -->
+                             <validationSet>
+                                 <dir>${agnostic.build.dir}/testing</dir>
                                  <includes>
                                      <include>**/*.xml</include>
+                                     <include>**/*.xsl</include>
                                  </includes>
                              </validationSet>
-                            <validationSet>
-                                <dir>${agnostic.build.dir}/testing/dspace/config/spring/xmlui</dir>
-                                 <includes>
-                                     <include>**/*.xml</include>
-                                 </includes>
-                            </validationSet>
-                            <validationSet>
-                                <dir>${agnostic.build.dir}/testing/dspace/config/pages</dir>
-                                 <includes>
-                                     <include>**/*.xml</include>
-                                 </includes>
-                             </validationSet>
-                             </validationSets>
-                        </configuration>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>xml-maven-plugin</artifactId>
-                        <version>1.0.1</version>
-                        <executions>
-                          <execution>
-                            <id>QQQvalidate-i18n-xml</id>
-                            <phase>process-test-resources</phase>
-                            <goals>
-                              <goal>validate</goal>
-                            </goals>
-                          </execution>
-                        </executions>
-                        <configuration>
-                          <validationSets>
-                            <validationSet>
-                                <dir>${agnostic.build.dir}/testing/dspace/config/spring/api</dir>
-                                 <includes>
-                                     <include>**/*.xml</include>
-                                 </includes>
-                             </validationSet>
-                            <validationSet>
-                                <dir>${agnostic.build.dir}/testing/dspace/config/spring/xmlui</dir>
-                                 <includes>
-                                     <include>**/*.xml</include>
-                                 </includes>
-                            </validationSet>
-                            <validationSet>
-                                <dir>${agnostic.build.dir}/testing/dspace/config/pages</dir>
-                                 <includes>
-                                     <include>**/*.xml</include>
-                                 </includes>
-                             </validationSet>
-                             </validationSets>
+                              </validationSets>
                         </configuration>
                     </plugin>
 

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -26,6 +26,39 @@
             <filter>${filters.file}</filter>
         </filters>
         <plugins>
+
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>xml-maven-plugin</artifactId>
+                    <version>1.0.1</version>
+                    <executions>
+                      <execution>
+                        <id>validate-xmlui-xml</id>
+                        <phase>test</phase>
+                        <goals>
+                          <goal>validate</goal>
+                        </goals>
+                      </execution>
+                    </executions>
+                    <configuration>
+                      <validationSets>
+                        <validationSet>
+                            <dir>${basedir}/dspace/config/spring/xmlui</dir>
+                             <includes>
+                                 <include>**/*.xml</include>
+                             </includes>
+                         </validationSet>
+                        <validationSet>
+                            <dir>${basedir}/dspace/config/pages</dir>
+                             <includes>
+                                 <include>**/*.xml</include>
+                             </includes>
+                         </validationSet>
+                       </validationSets>
+                    </configuration>
+                </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -44,13 +44,7 @@
                     <configuration>
                       <validationSets>
                         <validationSet>
-                            <dir>${basedir}/dspace/config/spring/xmlui</dir>
-                             <includes>
-                                 <include>**/*.xml</include>
-                             </includes>
-                         </validationSet>
-                        <validationSet>
-                            <dir>${basedir}/dspace/config/pages</dir>
+                            <dir>${basedir}/i18n/</dir>
                              <includes>
                                  <include>**/*.xml</include>
                              </includes>

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -26,35 +26,6 @@
             <filter>${filters.file}</filter>
         </filters>
         <plugins>
-
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>xml-maven-plugin</artifactId>
-                    <version>1.0.1</version>
-                    <executions>
-                      <execution>
-                        <id>validate-ALL-xmlui-xml-and-xsl</id>
-                        <phase>test</phase>
-                        <goals>
-                          <goal>validate</goal>
-                        </goals>
-                      </execution>
-                    </executions>
-                    <configuration>
-                      <validationSets>
-                        <!-- validate ALL XML and XSL files -->
-                        <validationSet>
-                            <dir>${basedir}</dir>
-                             <includes>
-                                 <include>**/*.xml</include>
-                                 <include>**/*.xsl</include>
-                             </includes>
-                         </validationSet>
-                       </validationSets>
-                    </configuration>
-                </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -34,7 +34,7 @@
                     <version>1.0.1</version>
                     <executions>
                       <execution>
-                        <id>validate-xmlui-xml</id>
+                        <id>validate-ALL-xmlui-xml-and-xsl</id>
                         <phase>test</phase>
                         <goals>
                           <goal>validate</goal>
@@ -43,10 +43,12 @@
                     </executions>
                     <configuration>
                       <validationSets>
+                        <!-- validate ALL XML and XSL files -->
                         <validationSet>
-                            <dir>${basedir}/i18n/</dir>
+                            <dir>${basedir}</dir>
                              <includes>
                                  <include>**/*.xml</include>
+                                 <include>**/*.xsl</include>
                              </includes>
                          </validationSet>
                        </validationSets>


### PR DESCRIPTION
This work uses the xml-maven-plugin to validate all XML and XSLT files in MOspace, as part of the testing process. This should ensure that all XML config files, as well as theme XSLT files, are well-formed, and prevent us from accepting pull requests that contain malformed XML or XSLT. It should also allow Travis-CI to inform contributors of this error condition, and allow them to correct any mistakes.
