### PR TITLE
Fixing issue with the authentication

### DIFF
--- a/dspace/config/modules/authentication.cfg
+++ b/dspace/config/modules/authentication.cfg
@@ -31,8 +31,8 @@
 #
 # Example Authentication Stack (Using Shibboleth & Authentication by Password):
 plugin.sequence.org.dspace.authenticate.AuthenticationMethod = \
-         org.dspace.authenticate.ShibAuthentication, \
-         org.dspace.authenticate.PasswordAuthentication
+         org.dspace.authenticate.PasswordAuthentication, \
+         org.dspace.authenticate.ShibAuthentication
 
 #plugin.sequence.org.dspace.authenticate.AuthenticationMethod = \
 #        org.dspace.authenticate.PasswordAuthentication


### PR DESCRIPTION
Switching order of authentication methods to avoid NullPointers when using PasswordAuthentication together with Shibboleth.

Shibboleth will create a new EPerson with email & netId set to NULL if password login is used.
